### PR TITLE
implemented check for platform to guarantee communication with bitbox

### DIFF
--- a/communication.js
+++ b/communication.js
@@ -17,6 +17,7 @@
 
 "use strict"
 
+const os = require('os');
 const hid = require('./hid')
 const cryptography = require('./cryptography')
 
@@ -91,6 +92,9 @@ function send(device, header, body, offset) {
   console.log('---- request ----');
   console.log(JSON.stringify(byteArray));
   console.log('-----------------');
+  if(os.platform() === 'win32') {
+    byteArray.unshift(0);
+  }
   device.write(byteArray)
   return bytesOfBody;
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "jquery": "^3.3.1",
     "node-hid": "^0.7.2",
-    "os": "^0.1.1",
     "pbkdf2": "^3.0.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "jquery": "^3.3.1",
     "node-hid": "^0.7.2",
+    "os": "^0.1.1",
     "pbkdf2": "^3.0.14"
   }
 }


### PR DESCRIPTION
Currently the implementation of communication.js will not work on windows platforms since bitbox does not react to any attempted sends. To guarantee this, it is necessary to first check for the platform this app is running on and if it is windows prepend a bit to the message. For further information see https://github.com/node-hid/node-hid#prepend-byte-to-hid_write