### PR TITLE
communication: HMAC for BitBox >= v5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,16 @@ yarn start
 
 ## License
 
-To be defined.
+Copyright (C) 2018 Shift Devices AG, Switzerland (info@shiftcrypto.ch)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/cryptography.js
+++ b/cryptography.js
@@ -22,6 +22,8 @@ const crypto = require("crypto");
 // 16 bytes, 128 bits block size for AES
 const AES_BLOCK_SIZE = 16;
 
+const SHA256_SIZE = 32;
+
 /**
  * Performs a double SHA-256 hash on the given data.
  * Used to stretch the key.
@@ -33,9 +35,16 @@ exports.doubleHash = function(data) {
 }
 
 /**
+ * Performs a SHA-512 hash on the given data.
+ */
+exports.sha512 = function(data) {
+  data = crypto.createHash('sha512').update(data).digest();
+  return data;
+}
+
+/**
  * Encrypts the given message with AES-256 using the CBC Cipher Mode.
- * When the encryption is done, the output is encoded as base64 string and 
- * handed to the given callback.
+ * Returns a buffer of encrypted bytes.
  */
 exports.encryptAES = function(key, msg, callback) {
   var iv = crypto.pseudoRandomBytes(AES_BLOCK_SIZE);
@@ -48,7 +57,7 @@ exports.encryptAES = function(key, msg, callback) {
     }
   });
   cipher.on('end', () => {
-    callback(encrypted.toString('base64'));
+    callback(encrypted);
   });
 
   // PKCS padding is appended, because autopadding is enabled by default.
@@ -57,13 +66,12 @@ exports.encryptAES = function(key, msg, callback) {
 }
 
 /**
- * Decodes and decrypts the given base64 encoded ciphertext using AES-256-CBC and
+ * Decodes and decrypts the given ciphertext using AES-256-CBC and
  * calls the callback upon successful decryption.
  */
-exports.decryptAES = function(key, encodedCiphertext, callback) {
-  var ciphertext_iv = Buffer.from(encodedCiphertext, 'base64');
-  var iv = ciphertext_iv.slice(0, AES_BLOCK_SIZE);
-  var ciphertext = ciphertext_iv.slice(AES_BLOCK_SIZE);
+exports.decryptAES = function(key, ciphertext_iv, callback) {
+  let iv = ciphertext_iv.slice(0, AES_BLOCK_SIZE);
+  let ciphertext = ciphertext_iv.slice(AES_BLOCK_SIZE);
   const cipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
   let decrypted = '';
   cipher.on('readable', () => {
@@ -80,3 +88,53 @@ exports.decryptAES = function(key, encodedCiphertext, callback) {
   cipher.write(ciphertext);
   cipher.end();
 }
+
+/**
+ * Calculates and appends an HMAC to the message.
+ */
+exports.appendHMAC = function(key, msg, callback) {
+  const hmac = crypto.createHmac('sha256', key);
+  hmac.on('readable', () => {
+    const data = hmac.read();
+    if (data) {
+      msg = Buffer.concat([msg, data]);
+    }
+  });
+  hmac.on('end', () => {
+    callback(msg);
+  });
+
+  // PKCS padding is appended, because autopadding is enabled by default.
+  hmac.write(msg);
+  hmac.end();
+}
+
+/**
+ * Calculates and verifies HMAC on message.
+ * If the verification is successful, it passes the message (without the HMAC
+ * appendix) to the successCallback.
+ */
+exports.checkHMAC = function(key, data, successCallback, errorCallback) {
+  const msg = data.slice(0, -SHA256_SIZE);
+  const receivedHmac = data.slice(-SHA256_SIZE);
+  const hmac = crypto.createHmac('sha256', key);
+  let computedHmac = Buffer.from([]);
+  hmac.on('readable', () => {
+    const data = hmac.read();
+    if (data) {
+      computedHmac = Buffer.concat([computedHmac, data]);
+    }
+  });
+  hmac.on('end', () => {
+    if (computedHmac.equals(receivedHmac)) {
+      successCallback(msg);
+    } else {
+      errorCallback("Message is corrupt");
+    }
+  });
+
+  // PKCS padding is appended, because autopadding is enabled by default.
+  hmac.write(msg);
+  hmac.end();
+}
+


### PR DESCRIPTION
Since BitBox v5.0.0, messages send to and received from the BitBox
are authenticated. Therefore, the application appends an HMAC
prior to sending a command to the BitBox and verifies a received HMAC
prior to decrypting the data received from the BitBox.
The fix is backwards-compatible so that BitBoxes <v5.0.0 continue to work.